### PR TITLE
Make `CurrentYear` dynamic for `<Copyright>`

### DIFF
--- a/template/src/PackageStarter/PackageStarter.csproj
+++ b/template/src/PackageStarter/PackageStarter.csproj
@@ -13,7 +13,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>0.1.0</Version>
     <Authors>AuthorName</Authors>
-    <Copyright>CurrentYear © AuthorName</Copyright>
+    <Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © AuthorName</Copyright>
     <PackageProjectUrl>https://github.com/GitHubUser/GitHubRepo</PackageProjectUrl>
     <RepositoryUrl>https://github.com/GitHubUser/GitHubRepo</RepositoryUrl>
     <PackageReadmeFile>README_nuget.md</PackageReadmeFile>


### PR DESCRIPTION
This ensures that we get the current year on build time, rather than when the package is created from the template. Then developers doesn't have to update it manually every year 😎 