### PR TITLE
Added wildcard to dotnet build command file path argument

### DIFF
--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         dotnet-version: 6.0.x
   
     - name: Build project
-      run: dotnet build src\PackageStarter\PackageStarter.csproj --configuration Release
+      run: dotnet build src\**\*.sln --configuration Release
 
     - name: Push to NuGet
       run: dotnet nuget push **\*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Hi Lotte, 

I noticed the dotnet build command has the path set statically which would require a user to manually change the path in the workflow when using the package starter.

I changed it src\**\*.sln so that it will find the sln no matter where it is in the src folder or what its name is.