### PR TITLE
Add dotnetcli.host.json with symbol info

### DIFF
--- a/template/.template.config/dotnetcli.host.json
+++ b/template/.template.config/dotnetcli.host.json
@@ -1,0 +1,17 @@
+﻿{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "authorName": {
+      "longName": "authorName",
+      "shortName": "an"
+    },
+    "githubUser": {
+      "longName": "githubUser",
+      "shortName": "gu"
+    },
+    "githubRepo": {
+      "longName": "githubRepo",
+      "shortName": "gr"
+    }
+  }
+}


### PR DESCRIPTION
The .template.config/dotnetcli.host.json file was added to the project. This file provides symbol information for authorName, githubUser, and githubRepo in the .NET CLI host.

It shorters up "authorName" to "an", ie. addresses #7 

![image](https://github.com/LottePitcher/opinionated-package-starter/assets/29239704/583ea0b7-090d-4da9-9d4e-63309010acbd)
