### PR TITLE
Add friendly package name derivation

### DIFF
--- a/template/.template.config/template.json
+++ b/template/.template.config/template.json
@@ -82,12 +82,31 @@
         "fallback": 5001
       },
       "replaces": "44390"
+    },
+    "friendlyPackageNameGenerated": {
+      "type": "derived",
+      "valueSource": "name",
+      "replaces": "FriendlyPackageName",
+      "valueTransform": "PascalCaseToSpaces"
+    },
+    "friendlyPackageName": {
+      "description": "The friendly name of the package.",
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "FriendlyPackageName"
+    }
+  },
+  "forms": {
+    "PascalCaseToSpaces": {
+      "identifier": "replace",
+      "pattern": "([A-Z][a-z]+)",
+      "replacement": "$1 "
     }
   },
   "primaryOutputs": [
     {
       "path": "src/PackageStarter/PackageStarter.csproj"
-    },   
+    },
     {
       "path": "src/PackageStarter/PackageStarter.TestSite.csproj"
     }

--- a/template/docs/README_nuget.md
+++ b/template/docs/README_nuget.md
@@ -1,4 +1,4 @@
-# PackageStarter
+# FriendlyPackageName
 
 [![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.PackageStarter?color=cc9900)](https://www.nuget.org/packages/Umbraco.Community.PackageStarter/)
 [![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.PackageStarter?color=0273B3)](https://www.nuget.org/packages/Umbraco.Community.PackageStarter)


### PR DESCRIPTION
This commit introduces a new feature to derive a friendly package name from the given name using Pascal case to space transformation. Added properties "friendlyPackageNameGenerated" and "friendlyPackageName" in template.json to achieve this. Attemps to resolved: #5 

It is possible for the `template.json` to transform from Pascal -> Title and this commit introduces it; as a bonus, you can also specify the `--friendlyPackageName` which takes precedence over the generated version.
![image](https://github.com/LottePitcher/opinionated-package-starter/assets/29239704/d7a6a5c7-a5b6-485e-ac7e-81b292d9dae5)

![image](https://github.com/LottePitcher/opinionated-package-starter/assets/29239704/47b29fb1-c8d9-4eaa-ae22-41b456d59bac)

![image](https://github.com/LottePitcher/opinionated-package-starter/assets/29239704/9248b6c6-9f54-4d83-9fb4-5a07bd3e7c3a)


