### PR TITLE
Should use double quotes

### DIFF
--- a/template/setup.cmd
+++ b/template/setup.cmd
@@ -12,7 +12,7 @@ dotnet new install Umbraco.Templates --force
 
 :: use the umbraco-extension dotnet template to add the package project
 cd src
-dotnet new umbraco-extension -n "PackageStarter" --site-domain 'https://localhost:44300' --include-example --allow-scripts Yes
+dotnet new umbraco-extension -n "PackageStarter" --site-domain "https://localhost:44300" --include-example --allow-scripts Yes
 
 :: replace package .csproj with the one from the template so has nuget info
 cd PackageStarter


### PR DESCRIPTION
I believe these should use double quotes as otherwise the string including single quotes gets passed through to `package.json` and it breaks the `generatr-api` script.