### PR TITLE
set launch url in properties (open./umbraco)

### DIFF
--- a/template/src/PackageStarter.TestSite/Properties/launchSettings.json
+++ b/template/src/PackageStarter.TestSite/Properties/launchSettings.json
@@ -11,6 +11,7 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
+      "launchUrl": "https://localhost:44300/umbraco",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -19,11 +20,12 @@
     "Umbraco.Web.UI": {
       "commandName": "Project",
       "dotnetRunMessages": true,
+      "launchUrl": "https://localhost:44300/umbraco",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44300;http://localhost:40000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }      
+      }
     }
   }
 }


### PR DESCRIPTION
Adds the `launchUrl` parameter in the site's launchSettings.json file, so when you run the site from Visual Studio (and maybe rider 🤷) it opens https://siteurl/umbraco instead of https://siteurl/. 

saving a whole click! (But loosing that lovely uSync all the things splash page 😞)