### PR TITLE
feat: run actions on ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,25 +5,23 @@ name: Release Package
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 9.0.x
- 
-    - name: Build & Pack
-      run: dotnet pack .\template-pack.csproj -c Release /p:Version=${{github.ref_name}}
+      - name: Build & Pack
+        run: dotnet pack ./template-pack.csproj -c Release /p:Version=${{github.ref_name}}
 
-    - name: Push to NuGet
-      run: dotnet nuget push **\*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json
+      - name: Push to NuGet
+        run: dotnet nuget push **/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -5,25 +5,23 @@ name: Release Package
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 9.0.x
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 9.0.x
+      - name: Build & Pack
+        run: dotnet pack src/PackageStarter/PackageStarter.csproj -c Release /p:Version=${{github.ref_name}}
 
-    - name: Build & Pack
-      run: dotnet pack src\PackageStarter\PackageStarter.csproj -c Release /p:Version=${{github.ref_name}}
-
-    - name: Push to NuGet
-      run: dotnet nuget push **\*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json
+      - name: Push to NuGet
+        run: dotnet nuget push **/*.nupkg -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Description

Fixes #26

Allows the template action to run on ubuntu-latest. This has been tested on https://github.com/iOvergaard/umbraco-servervariables

It also switches the repository's own action to ubuntu-latest.