### PR TITLE
Remove `--allow-scripts` option as it throws an error

### DIFF
--- a/template/setup.cmd
+++ b/template/setup.cmd
@@ -12,7 +12,7 @@ dotnet new install Umbraco.Templates --force
 
 :: use the umbraco-extension dotnet template to add the package project
 cd src
-dotnet new umbraco-extension -n "PackageStarter" --site-domain "https://localhost:44300" --include-example --allow-scripts Yes
+dotnet new umbraco-extension -n "PackageStarter" --site-domain "https://localhost:44300" --include-example
 
 :: replace package .csproj with the one from the template so has nuget info
 cd PackageStarter


### PR DESCRIPTION
I can't find this option ever existing in the umbraco-extension template, nor can I see it ever being removed.. strange.