### PR TITLE
Remove RazorCompileOnBuild/Publish from test site csproj

### DIFF
--- a/template/src/PackageStarter.TestSite/PackageStarter.TestSite.csproj
+++ b/template/src/PackageStarter.TestSite/PackageStarter.TestSite.csproj
@@ -22,10 +22,4 @@
     <CopyRazorGenerateFilesToPublishDirectory>true</CopyRazorGenerateFilesToPublishDirectory>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Remove RazorCompileOnBuild and RazorCompileOnPublish when not using ModelsMode InMemoryAuto -->
-    <RazorCompileOnBuild>false</RazorCompileOnBuild>
-    <RazorCompileOnPublish>false</RazorCompileOnPublish>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
## Summary

- Removes `RazorCompileOnBuild` and `RazorCompileOnPublish` properties from the test site `.csproj`

Fixes #54

## Why this needs to be removed

In Umbraco 17, Razor runtime compilation was moved out of the `Umbraco.Cms` metapackage into a separate opt-in package (`Umbraco.Cms.DevelopmentMode.Backoffice`). The `RazorCompileOnBuild=false` and `RazorCompileOnPublish=false` settings only make sense when using `InMemoryAuto` ModelsBuilder mode with runtime compilation — they tell the build system not to precompile Razor views because they'll be compiled at runtime instead.

The test site in this template uses `"ModelsMode": "Nothing"`, so runtime compilation is neither needed nor installed. With these properties still present, Razor views are prevented from being precompiled at build time, and there's no runtime compilation to fall back to — resulting in templates that can't be rendered.

See the [Umbraco 17 version-specific upgrade notes](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/upgrading/version-specific) for details.

## Test plan

- [ ] Install the template locally and generate a new package
- [ ] Verify the test site starts and Razor views render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)