### PR TITLE
Fix Central Package Management conflict in package csproj

### DIFF
--- a/template/src/PackageStarter/PackageStarter_nuget.csproj
+++ b/template/src/PackageStarter/PackageStarter_nuget.csproj
@@ -23,10 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.0.0" />
-    <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.0.0" />
-    <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.0.0" />
-    <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.0.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" />
+    <PackageReference Include="Umbraco.Cms.Api.Common" />
+    <PackageReference Include="Umbraco.Cms.Api.Management" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Removes hardcoded `Version` attributes from `PackageReference` items in `PackageStarter_nuget.csproj`

## Why

The `dotnet new umbraco-extension` template (v17+) now generates a `Directory.Packages.props` file that enables [Central Package Management (CPM)](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management). CPM requires that package versions are defined **only** in `Directory.Packages.props` via `<PackageVersion>` items — individual `.csproj` files must use `<PackageReference>` **without** a `Version` attribute.

During setup, the generated `.csproj` is replaced with `PackageStarter_nuget.csproj`, which had `Version="17.0.0"` on all four Umbraco package references. This conflicts with the `Directory.Packages.props` that `umbraco-extension` created, causing `dotnet restore` to fail with:

```
error NU1008: Projects using Central Package Management must define a Version value
on a PackageVersion item.
```

By removing the `Version` attributes, the `.csproj` defers to `Directory.Packages.props` for version resolution, which is the correct behavior under CPM.

## Test plan

- [ ] Install the template locally and generate a new package
- [ ] Verify `dotnet restore` succeeds without NU1008 errors
- [ ] Verify the package project builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)