### PR TITLE
Remove default `umbraco-marketplace` tag

### DIFF
--- a/.github/UsingTheTemplate.md
+++ b/.github/UsingTheTemplate.md
@@ -59,14 +59,22 @@ The template setup script has already initialised your local git repo and added 
 
 ## Publishing to nuget and the Umbraco Marketplace
 
-The package project .csproj has already been configured to have the `umbraco-marketplace` tag on the nuget package. This means that the Marketplace will automatically find and index the package once you have published it to nuget. If you don't want that to happen then remove this tag.
-
 Before you publish your package on nuget you should update:
 
 - The `.csproj` in the package project and set the Title property (and check the others)
 - `\.github\README.md` - this is the readme of your open source repository on GitHub
 - `.\docs\README_nuget.md` - this is the readme that will show on nuget.org
 - The `umbraco-marketplace.json` file in the root of your repository and update the `Category` property (see the [supported categories](https://docs.umbraco.com/umbraco-dxp/marketplace/listing-your-package#categories) for more information)
+
+### Publishing to the Umbraco Marketplace
+
+If you want your package to be published to the [Umbraco Marketplace](https://marketplace.umbraco.com), you need to add the `umbraco-marketplace` tag to your package on nuget. To do this:
+
+1. Open the package project `.csproj` file
+2. Find the `<PackageTags>` element and add `umbraco-marketplace` to the list of tags
+3. The tag should look like: `<PackageTags>umbraco;umbraco-marketplace</PackageTags>`
+
+Once you publish a nuget package with this tag, the Umbraco Marketplace will automatically find and index your package. Only add this tag when you're ready for your package to be listed publicly.
 
 ### Package logo
 

--- a/template/src/PackageStarter/PackageStarter_nuget.csproj
+++ b/template/src/PackageStarter/PackageStarter_nuget.csproj
@@ -11,7 +11,7 @@
     <PackageId>NUGET_PACKAGE_ID</PackageId>
     <Title>PACKAGE_TITLE</Title>
     <Description>...</Description>
-    <PackageTags>umbraco;umbraco-marketplace</PackageTags>
+    <PackageTags>umbraco</PackageTags>
     <Authors>AUTHOR_NAME</Authors>
     <Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © AUTHOR_NAME</Copyright>
     <PackageProjectUrl>https://github.com/GITHUB_USERNAME/GITHUB_REPOSITORY</PackageProjectUrl>
@@ -28,7 +28,7 @@
     <PackageReference Include="Umbraco.Cms.Api.Common" />
     <PackageReference Include="Umbraco.Cms.Api.Management" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <!-- Dont include the client folder as part of packaging nuget build -->
     <Content Remove="Client\**" />
@@ -36,7 +36,7 @@
     <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
     <None Include="Client\public\umbraco-package.json" Pack="false" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="..\..\docs\README_nuget.md">
       <Pack>True</Pack>


### PR DESCRIPTION
## Description

Changes [Umbraco Marketplace](https://marketplace.umbraco.com/) publishing to **opt-in** instead of opt-out.

### What Changed

- **Removed** the default `umbraco-marketplace` tag from the generated package `.csproj` file.
- **Updated** the documentation in `UsingTheTemplate.md` to reflect this change, with a new section explaining how to optionally add the marketplace tag when ready to publish.

### Why

This ensures packages don't accidentally get indexed on the [Umbraco Marketplace](https://marketplace.umbraco.com/) when using this template for testing or experimentation. The marketplace tag is only added when you explicitly intend the package to be listed.

### For Users

When generating a new package from the template, users will need to:

1. Explicitly add the `umbraco-marketplace` tag to their package's `.csproj` if they want it indexed by the Marketplace.
2. Follow the updated instructions in `UsingTheTemplate.md`, which now includes a clear step-by-step guide for enabling marketplace publishing.